### PR TITLE
feat(projections): add support for ClickHouse projections in query generation

### DIFF
--- a/internal/clickhouse/types.go
+++ b/internal/clickhouse/types.go
@@ -3,11 +3,12 @@ package clickhouse
 
 // Table represents a ClickHouse table structure with its columns and metadata
 type Table struct {
-	Name       string
-	Database   string
-	Comment    string
-	Columns    []Column
-	SortingKey []string // ORDER BY columns
+	Name        string
+	Database    string
+	Comment     string
+	Columns     []Column
+	SortingKey  []string // ORDER BY columns
+	Projections []Projection
 }
 
 // Column represents a ClickHouse table column with its properties
@@ -30,4 +31,11 @@ type TableMetadata struct {
 	Engine      string
 	CreateTable string
 	Comment     string
+}
+
+// Projection represents a ClickHouse projection with its properties
+type Projection struct {
+	Name       string
+	OrderByKey []string // ORDER BY columns for the projection
+	Type       string   // Type of projection (e.g., "AGGREGATE")
 }

--- a/internal/protogen/sql_common.go
+++ b/internal/protogen/sql_common.go
@@ -79,6 +79,8 @@ type QueryOptions struct {
 	AddFinal bool
 	// Database optionally specifies the database name
 	Database string
+	// Projection optionally specifies the projection to use
+	Projection string
 }
 
 // QueryOption is a functional option for query configuration
@@ -95,6 +97,13 @@ func WithFinal() QueryOption {
 func WithDatabase(database string) QueryOption {
 	return func(opts *QueryOptions) {
 		opts.Database = database
+	}
+}
+
+// WithProjection specifies the projection to use
+func WithProjection(projection string) QueryOption {
+	return func(opts *QueryOptions) {
+		opts.Projection = projection
 	}
 }
 
@@ -415,6 +424,12 @@ func BuildParameterizedQuery(table string, qb *QueryBuilder, orderByClause strin
 	} else {
 		fromClause = table
 	}
+	
+	// Add projection if specified
+	if opts.Projection != "" {
+		fromClause = fmt.Sprintf("%s PROJECTION %s", fromClause, opts.Projection)
+	}
+	
 	if opts.AddFinal {
 		fromClause += " FINAL"
 	}


### PR DESCRIPTION
- Load projections from system.projections table for both regular and distributed tables
- Add Projection type with name, order by key, and type fields
- Support WithProjection() query option to utilize specific projections
- Enhance primary key validation to check both base table and projection keys
- Document available projections in generated SQL builder functions
- Add comprehensive tests for projection support