### PR TITLE
fix: ensure deterministic ordering of primary keys in generated code

### DIFF
--- a/internal/protogen/sql_helper_test.go
+++ b/internal/protogen/sql_helper_test.go
@@ -231,7 +231,7 @@ func TestSQLHelperWithProjections(t *testing.T) {
 			},
 			expectedInCode: []string{
 				"// Validate that at least one primary key is provided",
-				"at least one primary key field is required: log_id, level, host",
+				"at least one primary key field is required: host, level, log_id",
 				"// Available projections:",
 				"//   - by_level (primary key: level)",
 				"//   - by_host (primary key: host)",


### PR DESCRIPTION
Sort primary key names alphabetically to prevent non-deterministic output when generating validation conditions and error messages