### PR TITLE
refactor(protogen): replace SELECT * with explicit column list

### DIFF
--- a/internal/protogen/sql_common.go
+++ b/internal/protogen/sql_common.go
@@ -474,10 +474,9 @@ func BuildOrderByClause(fields []OrderByField) string {
 // validColumnNamePattern is compiled once for performance
 var validColumnNamePattern = regexp.MustCompile("^[a-zA-Z0-9_.]+$")
 
-// isValidColumnName validates column names to prevent SQL injection
+// isValidColumnName validates column names.
 // Only allows alphanumeric characters, underscores, and dots (for nested fields)
 func isValidColumnName(name string) bool {
-	// This is a conservative approach for security
 	return len(name) > 0 && len(name) < 128 && validColumnNamePattern.MatchString(name)
 }
 
@@ -496,12 +495,12 @@ func BuildParameterizedQuery(table string, columns []string, qb *QueryBuilder, o
 	} else {
 		fromClause = table
 	}
-	
+
 	// Add projection if specified
 	if opts.Projection != "" {
 		fromClause = fmt.Sprintf("%s PROJECTION %s", fromClause, opts.Projection)
 	}
-	
+
 	if opts.AddFinal {
 		fromClause += " FINAL"
 	}
@@ -513,14 +512,14 @@ func BuildParameterizedQuery(table string, columns []string, qb *QueryBuilder, o
 
 	escapedColumns := make([]string, 0, len(columns))
 	for _, col := range columns {
-		// Validate column name for SQL injection protection
 		if !isValidColumnName(col) {
 			return SQLQuery{}, fmt.Errorf("invalid column name: %s", col)
 		}
+
 		// Escape column names with backticks if they contain dots (for nested fields)
-		// or if they might be reserved words
+		// or if they might be reserved words.
 		if strings.Contains(col, ".") {
-			// For nested fields like "address.street", escape each part
+			// For nested fields like "abc.xyz", escape each part.
 			parts := strings.Split(col, ".")
 			escapedParts := make([]string, len(parts))
 			for i, part := range parts {
@@ -528,7 +527,6 @@ func BuildParameterizedQuery(table string, columns []string, qb *QueryBuilder, o
 			}
 			escapedColumns = append(escapedColumns, strings.Join(escapedParts, "."))
 		} else {
-			// Simple column name - add backticks for safety
 			escapedColumns = append(escapedColumns, fmt.Sprintf("` + "`" + `%s` + "`" + `", col))
 		}
 	}

--- a/internal/protogen/sql_helper.go
+++ b/internal/protogen/sql_helper.go
@@ -189,7 +189,17 @@ func (g *Generator) writeSQLBuilderFunction(sb *strings.Builder, table *clickhou
 	}
 	fmt.Fprintf(sb, "\t}\n\n")
 
-	fmt.Fprintf(sb, "\treturn BuildParameterizedQuery(\"%s\", qb, orderByClause, limit, offset, options...), nil\n", table.Name)
+	// Build column list for explicit selection
+	fmt.Fprintf(sb, "\t// Build column list\n")
+	fmt.Fprintf(sb, "\tcolumns := []string{")
+	for i, col := range table.Columns {
+		if i > 0 {
+			fmt.Fprintf(sb, ", ")
+		}
+		fmt.Fprintf(sb, "\"%s\"", col.Name)
+	}
+	fmt.Fprintf(sb, "}\n\n")
+	fmt.Fprintf(sb, "\treturn BuildParameterizedQuery(\"%s\", columns, qb, orderByClause, limit, offset, options...)\n", table.Name)
 	fmt.Fprintf(sb, "}\n")
 }
 
@@ -258,8 +268,18 @@ func (g *Generator) writeGetSQLBuilderFunction(sb *strings.Builder, table *click
 		// No sorting key, generate simple query without primary key
 		fmt.Fprintf(sb, "\t// Table has no primary key\n")
 		fmt.Fprintf(sb, "\tqb := NewQueryBuilder()\n\n")
+		// Build column list for explicit selection
+		fmt.Fprintf(sb, "\t// Build column list\n")
+		fmt.Fprintf(sb, "\tcolumns := []string{")
+		for i, col := range table.Columns {
+			if i > 0 {
+				fmt.Fprintf(sb, ", ")
+			}
+			fmt.Fprintf(sb, "\"%s\"", col.Name)
+		}
+		fmt.Fprintf(sb, "}\n\n")
 		fmt.Fprintf(sb, "\t// Return single record\n")
-		fmt.Fprintf(sb, "\treturn BuildParameterizedQuery(\"%s\", qb, \"\", 1, 0, options...), nil\n", table.Name)
+		fmt.Fprintf(sb, "\treturn BuildParameterizedQuery(\"%s\", columns, qb, \"\", 1, 0, options...)\n", table.Name)
 		fmt.Fprintf(sb, "}\n")
 		return
 	}
@@ -313,9 +333,20 @@ func (g *Generator) writeGetSQLBuilderFunction(sb *strings.Builder, table *click
 	}
 	fmt.Fprintf(sb, "\"\n\n")
 
+	// Build column list for explicit selection
+	fmt.Fprintf(sb, "\t// Build column list\n")
+	fmt.Fprintf(sb, "\tcolumns := []string{")
+	for i, col := range table.Columns {
+		if i > 0 {
+			fmt.Fprintf(sb, ", ")
+		}
+		fmt.Fprintf(sb, "\"%s\"", col.Name)
+	}
+	fmt.Fprintf(sb, "}\n\n")
+
 	// Return query with LIMIT 1
 	fmt.Fprintf(sb, "\t// Return single record\n")
-	fmt.Fprintf(sb, "\treturn BuildParameterizedQuery(\"%s\", qb, orderByClause, 1, 0, options...), nil\n", table.Name)
+	fmt.Fprintf(sb, "\treturn BuildParameterizedQuery(\"%s\", columns, qb, orderByClause, 1, 0, options...)\n", table.Name)
 	fmt.Fprintf(sb, "}\n")
 }
 


### PR DESCRIPTION
Modified the SQL query generation to use explicit column lists instead of `SELECT *`. This change affects the core `BuildParameterizedQuery` function and all generated SQL helper code.

`SELECT *` was causing problems when database schemas evolved:

- Breaking changes for consumers: New columns added to the database cause proto unmarshal errors for clients using older generated code
- Performance overhead: Transfers unnecessary data when only specific columns are needed
- Hidden dependencies: No visibility into which columns a query actually uses

1. Updated BuildParameterizedQuery signature:
```go
  // Before
  func BuildParameterizedQuery(table string, qb *QueryBuilder, ...) SQLQuery
```

```go
  // After
  func BuildParameterizedQuery(table string, columns []string, qb *QueryBuilder, ...) (SQLQuery, error)
```

2. Modified SQL generation:
```sql
-- Before
SELECT * FROM users
```

```sql
-- After
SELECT `id`, `name`, `email`, `created_at` FROM users
```