### PR TITLE
fix: add GetValue() for Between.Max on all numeric filter types

### DIFF
--- a/internal/protogen/sql_helper.go
+++ b/internal/protogen/sql_helper.go
@@ -577,7 +577,7 @@ func (g *Generator) writeNumericFilterCases(sb *strings.Builder, columnName, ind
 	fmt.Fprintf(sb, "%s\tqb.AddCondition(\"%s\", \">=\", filter.Gte)\n", indent, columnName)
 
 	fmt.Fprintf(sb, "%scase *%sFilter_Between:\n", indent, typePrefix)
-	fmt.Fprintf(sb, "%s\tqb.AddBetweenCondition(\"%s\", filter.Between.Min, filter.Between.Max)\n", indent, columnName)
+	fmt.Fprintf(sb, "%s\tqb.AddBetweenCondition(\"%s\", filter.Between.Min, filter.Between.Max.GetValue())\n", indent, columnName)
 
 	fmt.Fprintf(sb, "%scase *%sFilter_In:\n", indent, typePrefix)
 	fmt.Fprintf(sb, "%s\tif len(filter.In.Values) > 0 {\n", indent)
@@ -615,7 +615,7 @@ func (g *Generator) writeNullableNumericFilterCases(sb *strings.Builder, columnN
 	fmt.Fprintf(sb, "%s\tqb.AddCondition(\"%s\", \">=\", filter.Gte)\n", indent, columnName)
 
 	fmt.Fprintf(sb, "%scase *%sFilter_Between:\n", indent, typePrefix)
-	fmt.Fprintf(sb, "%s\tqb.AddBetweenCondition(\"%s\", filter.Between.Min, filter.Between.Max)\n", indent, columnName)
+	fmt.Fprintf(sb, "%s\tqb.AddBetweenCondition(\"%s\", filter.Between.Min, filter.Between.Max.GetValue())\n", indent, columnName)
 
 	fmt.Fprintf(sb, "%scase *%sFilter_In:\n", indent, typePrefix)
 	fmt.Fprintf(sb, "%s\tif len(filter.In.Values) > 0 {\n", indent)


### PR DESCRIPTION
All Range types (UInt32Range, UInt64Range, Int32Range, Int64Range) have their Max field as a wrapper pointer (*wrapperspb.UInt32Value, etc.) that requires GetValue() to be called. This fix applies to both regular and nullable numeric filters.

This resolves 174 compilation issues across generated proto code where Between.Max was accessed directly without GetValue().