### PR TITLE
feat(protogen): add full filtering support for Array columns

### DIFF
--- a/internal/protogen/common.go
+++ b/internal/protogen/common.go
@@ -363,6 +363,97 @@ func (g *Generator) writeRangeTypes(sb *strings.Builder) {
 	sb.WriteString("    StringList has_all_keys = 5;            // mapContainsAll(mapColumn, ['k1', 'k2'])\n")
 	sb.WriteString("  }\n")
 	sb.WriteString("}\n\n")
+
+	// Array filter types
+	g.writeArrayFilterTypes(sb)
+}
+
+// writeArrayFilterTypes generates Array*Filter message types for filtering Array columns
+func (g *Generator) writeArrayFilterTypes(sb *strings.Builder) {
+	// ArrayUInt32Filter
+	sb.WriteString("// ArrayUInt32Filter represents filtering options for Array(UInt32) columns\n")
+	sb.WriteString("message ArrayUInt32Filter {\n")
+	sb.WriteString("  oneof filter {\n")
+	sb.WriteString("    uint32 has = 1;                         // has(arr, value) - array contains value\n")
+	sb.WriteString("    UInt32List has_all = 2;                 // hasAll(arr, [v1, v2]) - contains all values\n")
+	sb.WriteString("    UInt32List has_any = 3;                 // hasAny(arr, [v1, v2]) - contains any value\n")
+	sb.WriteString("    uint32 length_eq = 4;                   // length(arr) = n\n")
+	sb.WriteString("    uint32 length_gt = 5;                   // length(arr) > n\n")
+	sb.WriteString("    uint32 length_gte = 6;                  // length(arr) >= n\n")
+	sb.WriteString("    uint32 length_lt = 7;                   // length(arr) < n\n")
+	sb.WriteString("    uint32 length_lte = 8;                  // length(arr) <= n\n")
+	sb.WriteString("    google.protobuf.Empty is_empty = 9;     // empty(arr)\n")
+	sb.WriteString("    google.protobuf.Empty is_not_empty = 10; // notEmpty(arr)\n")
+	sb.WriteString("  }\n")
+	sb.WriteString("}\n\n")
+
+	// ArrayUInt64Filter
+	sb.WriteString("// ArrayUInt64Filter represents filtering options for Array(UInt64) columns\n")
+	sb.WriteString("message ArrayUInt64Filter {\n")
+	sb.WriteString("  oneof filter {\n")
+	sb.WriteString("    uint64 has = 1;                         // has(arr, value) - array contains value\n")
+	sb.WriteString("    UInt64List has_all = 2;                 // hasAll(arr, [v1, v2]) - contains all values\n")
+	sb.WriteString("    UInt64List has_any = 3;                 // hasAny(arr, [v1, v2]) - contains any value\n")
+	sb.WriteString("    uint32 length_eq = 4;                   // length(arr) = n\n")
+	sb.WriteString("    uint32 length_gt = 5;                   // length(arr) > n\n")
+	sb.WriteString("    uint32 length_gte = 6;                  // length(arr) >= n\n")
+	sb.WriteString("    uint32 length_lt = 7;                   // length(arr) < n\n")
+	sb.WriteString("    uint32 length_lte = 8;                  // length(arr) <= n\n")
+	sb.WriteString("    google.protobuf.Empty is_empty = 9;     // empty(arr)\n")
+	sb.WriteString("    google.protobuf.Empty is_not_empty = 10; // notEmpty(arr)\n")
+	sb.WriteString("  }\n")
+	sb.WriteString("}\n\n")
+
+	// ArrayInt32Filter
+	sb.WriteString("// ArrayInt32Filter represents filtering options for Array(Int32) columns\n")
+	sb.WriteString("message ArrayInt32Filter {\n")
+	sb.WriteString("  oneof filter {\n")
+	sb.WriteString("    int32 has = 1;                          // has(arr, value) - array contains value\n")
+	sb.WriteString("    Int32List has_all = 2;                  // hasAll(arr, [v1, v2]) - contains all values\n")
+	sb.WriteString("    Int32List has_any = 3;                  // hasAny(arr, [v1, v2]) - contains any value\n")
+	sb.WriteString("    uint32 length_eq = 4;                   // length(arr) = n\n")
+	sb.WriteString("    uint32 length_gt = 5;                   // length(arr) > n\n")
+	sb.WriteString("    uint32 length_gte = 6;                  // length(arr) >= n\n")
+	sb.WriteString("    uint32 length_lt = 7;                   // length(arr) < n\n")
+	sb.WriteString("    uint32 length_lte = 8;                  // length(arr) <= n\n")
+	sb.WriteString("    google.protobuf.Empty is_empty = 9;     // empty(arr)\n")
+	sb.WriteString("    google.protobuf.Empty is_not_empty = 10; // notEmpty(arr)\n")
+	sb.WriteString("  }\n")
+	sb.WriteString("}\n\n")
+
+	// ArrayInt64Filter
+	sb.WriteString("// ArrayInt64Filter represents filtering options for Array(Int64) columns\n")
+	sb.WriteString("message ArrayInt64Filter {\n")
+	sb.WriteString("  oneof filter {\n")
+	sb.WriteString("    int64 has = 1;                          // has(arr, value) - array contains value\n")
+	sb.WriteString("    Int64List has_all = 2;                  // hasAll(arr, [v1, v2]) - contains all values\n")
+	sb.WriteString("    Int64List has_any = 3;                  // hasAny(arr, [v1, v2]) - contains any value\n")
+	sb.WriteString("    uint32 length_eq = 4;                   // length(arr) = n\n")
+	sb.WriteString("    uint32 length_gt = 5;                   // length(arr) > n\n")
+	sb.WriteString("    uint32 length_gte = 6;                  // length(arr) >= n\n")
+	sb.WriteString("    uint32 length_lt = 7;                   // length(arr) < n\n")
+	sb.WriteString("    uint32 length_lte = 8;                  // length(arr) <= n\n")
+	sb.WriteString("    google.protobuf.Empty is_empty = 9;     // empty(arr)\n")
+	sb.WriteString("    google.protobuf.Empty is_not_empty = 10; // notEmpty(arr)\n")
+	sb.WriteString("  }\n")
+	sb.WriteString("}\n\n")
+
+	// ArrayStringFilter
+	sb.WriteString("// ArrayStringFilter represents filtering options for Array(String) columns\n")
+	sb.WriteString("message ArrayStringFilter {\n")
+	sb.WriteString("  oneof filter {\n")
+	sb.WriteString("    string has = 1;                         // has(arr, value) - array contains value\n")
+	sb.WriteString("    StringList has_all = 2;                 // hasAll(arr, [v1, v2]) - contains all values\n")
+	sb.WriteString("    StringList has_any = 3;                 // hasAny(arr, [v1, v2]) - contains any value\n")
+	sb.WriteString("    uint32 length_eq = 4;                   // length(arr) = n\n")
+	sb.WriteString("    uint32 length_gt = 5;                   // length(arr) > n\n")
+	sb.WriteString("    uint32 length_gte = 6;                  // length(arr) >= n\n")
+	sb.WriteString("    uint32 length_lt = 7;                   // length(arr) < n\n")
+	sb.WriteString("    uint32 length_lte = 8;                  // length(arr) <= n\n")
+	sb.WriteString("    google.protobuf.Empty is_empty = 9;     // empty(arr)\n")
+	sb.WriteString("    google.protobuf.Empty is_not_empty = 10; // notEmpty(arr)\n")
+	sb.WriteString("  }\n")
+	sb.WriteString("}\n\n")
 }
 
 func (g *Generator) writeCommonTypes(sb *strings.Builder) {

--- a/internal/protogen/mapper.go
+++ b/internal/protogen/mapper.go
@@ -537,11 +537,32 @@ func (tm *TypeMapper) getScalarFilterType(column *clickhouse.Column) string {
 	return baseFilterType
 }
 
+// getArrayFilterType returns the filter type for Array columns
+func (tm *TypeMapper) getArrayFilterType(column *clickhouse.Column) string {
+	protoType := tm.mapBaseType(column.BaseType, column.Type)
+
+	switch protoType {
+	case protoInt32:
+		return "ArrayInt32Filter"
+	case protoInt64:
+		return "ArrayInt64Filter"
+	case protoUInt32:
+		return "ArrayUInt32Filter"
+	case protoUInt64:
+		return "ArrayUInt64Filter"
+	case protoString:
+		return "ArrayStringFilter"
+	default:
+		// Unsupported array element type
+		return ""
+	}
+}
+
 // GetFilterTypeForColumn returns the appropriate filter type for a column based on its type and nullability
 func (tm *TypeMapper) GetFilterTypeForColumn(column *clickhouse.Column, tableName string, convConfig *config.ConversionConfig) string {
-	// Arrays don't use filter types
+	// Arrays use dedicated array filter types
 	if column.IsArray {
-		return ""
+		return tm.getArrayFilterType(column)
 	}
 
 	// Check if this Int64/UInt64 should be converted to string

--- a/internal/protogen/sql_common.go
+++ b/internal/protogen/sql_common.go
@@ -542,6 +542,60 @@ func StringSliceToInterface(values []string) []interface{} {
 	}
 	return result
 }
+
+// AddArrayHasCondition adds a has(array, value) condition
+func (qb *QueryBuilder) AddArrayHasCondition(column string, value interface{}) {
+	placeholder := qb.formatVariable(qb.argCounter)
+	qb.conditions = append(qb.conditions, fmt.Sprintf("has(%s, %s)", column, placeholder))
+	qb.args = append(qb.args, value)
+	qb.argCounter++
+}
+
+// AddArrayHasAllCondition adds a hasAll(array, [values]) condition
+func (qb *QueryBuilder) AddArrayHasAllCondition(column string, values []interface{}) {
+	if len(values) == 0 {
+		return
+	}
+	placeholders := make([]string, len(values))
+	for i, v := range values {
+		placeholders[i] = qb.formatVariable(qb.argCounter)
+		qb.args = append(qb.args, v)
+		qb.argCounter++
+	}
+	qb.conditions = append(qb.conditions, fmt.Sprintf("hasAll(%s, [%s])", column, strings.Join(placeholders, ", ")))
+}
+
+// AddArrayHasAnyCondition adds a hasAny(array, [values]) condition
+func (qb *QueryBuilder) AddArrayHasAnyCondition(column string, values []interface{}) {
+	if len(values) == 0 {
+		return
+	}
+	placeholders := make([]string, len(values))
+	for i, v := range values {
+		placeholders[i] = qb.formatVariable(qb.argCounter)
+		qb.args = append(qb.args, v)
+		qb.argCounter++
+	}
+	qb.conditions = append(qb.conditions, fmt.Sprintf("hasAny(%s, [%s])", column, strings.Join(placeholders, ", ")))
+}
+
+// AddArrayLengthCondition adds a length(array) op value condition
+func (qb *QueryBuilder) AddArrayLengthCondition(column, operator string, length uint32) {
+	placeholder := qb.formatVariable(qb.argCounter)
+	qb.conditions = append(qb.conditions, fmt.Sprintf("length(%s) %s %s", column, operator, placeholder))
+	qb.args = append(qb.args, length)
+	qb.argCounter++
+}
+
+// AddArrayIsEmptyCondition adds an empty(array) condition
+func (qb *QueryBuilder) AddArrayIsEmptyCondition(column string) {
+	qb.conditions = append(qb.conditions, fmt.Sprintf("empty(%s)", column))
+}
+
+// AddArrayIsNotEmptyCondition adds a notEmpty(array) condition
+func (qb *QueryBuilder) AddArrayIsNotEmptyCondition(column string) {
+	qb.conditions = append(qb.conditions, fmt.Sprintf("notEmpty(%s)", column))
+}
 `)
 
 	// Add page token and order by helper functions


### PR DESCRIPTION
- Generate dedicated Array*Filter message types for UInt32, UInt64, Int32, Int64 and String arrays with has/hasAll/hasAny, length and empty/notEmpty operators.
- Teach TypeMapper to return the correct ArrayXxxFilter instead of an empty string for array columns.
- Extend QueryBuilder with helper methods that emit ClickHouse has/hasAll/hasAny, length, empty and notEmpty SQL functions.
- Generate switch cases in SQL helpers so incoming Array*Filter protobuf messages are translated into the new query-builder calls.

This allows API consumers to filter on array contents and properties without manual SQL construction.