### PR TITLE
fix: handle function expressions in sorting key parsing

### DIFF
--- a/internal/clickhouse/client.go
+++ b/internal/clickhouse/client.go
@@ -523,21 +523,28 @@ func (s *service) loadDistributedTableProjections(ctx context.Context, database,
 }
 
 // parseSortingKey parses the sorting key expression from ClickHouse
-// It handles expressions like "column1, column2" or "column1 ASC, column2 DESC"
+// It handles expressions like "column1, column2", "column1 ASC, column2 DESC",
+// and function expressions like "rank, ifNull(expiry_policy, ”)"
 func parseSortingKey(sortingKey string) []string {
 	if sortingKey == "" {
 		return nil
 	}
 
-	// Split by comma
-	parts := strings.Split(sortingKey, ",")
+	// Split by comma, but respect parentheses nesting
+	// (e.g., "rank, ifNull(expiry_policy, '')" should split into ["rank", "ifNull(expiry_policy, '')"])
+	parts := splitSortingKeyParts(sortingKey)
 	columns := make([]string, 0, len(parts))
 
 	for _, part := range parts {
 		part = strings.TrimSpace(part)
-		// Remove ASC/DESC modifiers and any parentheses
+		// Remove ASC/DESC modifiers
 		part = strings.TrimSuffix(strings.TrimSuffix(part, " ASC"), " DESC")
-		part = strings.Trim(part, "()")
+
+		// Strip outer tuple parentheses (e.g., "(id)" -> "id") but NOT function calls.
+		// Tuple parens start with '(' immediately, function calls have a name before '('.
+		if len(part) >= 2 && part[0] == '(' && part[len(part)-1] == ')' {
+			part = part[1 : len(part)-1]
+		}
 
 		if part != "" {
 			columns = append(columns, part)
@@ -545,4 +552,33 @@ func parseSortingKey(sortingKey string) []string {
 	}
 
 	return columns
+}
+
+// splitSortingKeyParts splits a sorting key string by commas while respecting
+// parentheses nesting. Commas inside function calls are not treated as separators.
+func splitSortingKeyParts(s string) []string {
+	parts := make([]string, 0, 4)
+	depth := 0
+	start := 0
+
+	for i, ch := range s {
+		switch ch {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+
+	// Add the last part
+	if start < len(s) {
+		parts = append(parts, s[start:])
+	}
+
+	return parts
 }

--- a/internal/clickhouse/client_test.go
+++ b/internal/clickhouse/client_test.go
@@ -137,11 +137,87 @@ func TestParseSortingKey(t *testing.T) {
 			input:    "  id  ,   created_at   ,  name  ",
 			expected: []string{"id", "created_at", "name"},
 		},
+		{
+			name:     "Function expression with ifNull",
+			input:    "rank, ifNull(expiry_policy, '')",
+			expected: []string{"rank", "ifNull(expiry_policy, '')"},
+		},
+		{
+			name:     "Function expression with coalesce",
+			input:    "id, coalesce(name, 'unknown')",
+			expected: []string{"id", "coalesce(name, 'unknown')"},
+		},
+		{
+			name:     "Multiple function expressions",
+			input:    "rank, ifNull(policy, ''), coalesce(status, 'active')",
+			expected: []string{"rank", "ifNull(policy, '')", "coalesce(status, 'active')"},
+		},
+		{
+			name:     "Nested function expressions",
+			input:    "id, ifNull(coalesce(a, b), '')",
+			expected: []string{"id", "ifNull(coalesce(a, b), '')"},
+		},
+		{
+			name:     "Function with multiple args",
+			input:    "cityHash64(user_id, timestamp), created_at",
+			expected: []string{"cityHash64(user_id, timestamp)", "created_at"},
+		},
+		{
+			name:     "Mixed columns and functions with ASC/DESC",
+			input:    "rank ASC, ifNull(expiry_policy, '') DESC",
+			expected: []string{"rank", "ifNull(expiry_policy, '')"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := parseSortingKey(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSplitSortingKeyParts(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "Simple columns",
+			input:    "a, b, c",
+			expected: []string{"a", " b", " c"},
+		},
+		{
+			name:     "Function with comma",
+			input:    "rank, ifNull(policy, '')",
+			expected: []string{"rank", " ifNull(policy, '')"},
+		},
+		{
+			name:     "Nested functions",
+			input:    "a, f(g(x, y), z)",
+			expected: []string{"a", " f(g(x, y), z)"},
+		},
+		{
+			name:     "Multiple nested parens",
+			input:    "mod(cityHash64(concat(a, b)), 10), x",
+			expected: []string{"mod(cityHash64(concat(a, b)), 10)", " x"},
+		},
+		{
+			name:     "Empty input",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "Single column",
+			input:    "id",
+			expected: []string{"id"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := splitSortingKeyParts(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
The parseSortingKey function was naively splitting on all commas, which broke function expressions like ifNull(expiry_policy, '').

This caused malformed ORDER BY clauses in generated SQL:
  ORDER BY rank, ifNull(expiry_policy  <- missing closing paren

Added splitSortingKeyParts helper that respects parentheses nesting when splitting, so function calls with comma-separated arguments are preserved intact.

Fixes SQL generation for tables with ORDER BY expressions like:
  ORDER BY (rank, ifNull(expiry_policy, ''))