### PR TITLE
chore: fixes + modernize

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -17,13 +17,13 @@ jobs:
     steps:
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: '1.24'
+          go-version: '1.26'
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v2.3.0
+          version: v2.12.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: '1.23'
+          go-version: '1.26'
       - name: Run apt-get update
         run: sudo apt-get update
       - name: Install cross-compiler for linux/arm64
@@ -80,4 +80,4 @@ jobs:
             -e DOCKER_PASSWORD=${{ secrets.DOCKERHUB_TOKEN }} \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e RELEASE_SUFFIX=${{ env.RELEASE_SUFFIX }} \
-            goreleaser/goreleaser-cross:v1.22.2 release --clean --config .goreleaser.yaml.new
+            goreleaser/goreleaser-cross:v1.26.3 release --clean --config .goreleaser.yaml.new

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: '1.24'
+          go-version: '1.26'
       - name: Run apt-get update
         run: sudo apt-get update
       - name: Install cross-compiler for linux/arm64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
   full_ci:
     strategy:
       matrix:
-        go_version: [ 1.24.x ]
+        go_version: [ 1.6.x ]
 
     runs-on: ubuntu-latest
 
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: ${{ matrix.go_version }}
-        
+
       - name: run tests
         run: go test -json ./... > test.json
 
@@ -31,4 +31,3 @@ jobs:
         uses: guyarb/golang-test-annotations@2941118d7ef622b1b3771d1ff6eae9e90659eb26 # v0.8.0
         with:
           test-results: test.json
-         

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
   full_ci:
     strategy:
       matrix:
-        go_version: [ 1.6.x ]
+        go_version: [ 1.26.x ]
 
     runs-on: ubuntu-latest
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+golang 1.26.3
+golangci-lint 2.12.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.24 AS builder
+FROM golang:1.26 AS builder
 WORKDIR /src
 COPY go.sum go.mod ./
 RUN go mod download
 COPY . .
-RUN go build -o /bin/app .
+RUN go build -o /bin/app ./cmd/clickhouse-proto-gen
 
 FROM ubuntu:latest
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ See [config.example.yaml](config.example.yaml) for a complete example with all a
 | `--include-comments` | Include comments in proto | true |
 | `--max-page-size` | Maximum page size for List operations | 10000 |
 | `--bigint-to-string` | Convert Int64/UInt64 fields to string (see below) | - |
+| `--enable-api` | Emit `google.api.http` annotations for REST endpoints | false |
+| `--api-base-path` | Base path for API endpoints (requires `--enable-api`) | `/api/v1` |
+| `--api-table-prefixes` | Only expose tables matching these prefixes via REST (e.g. `fct_,dim_`) | - |
 | `--config` | Path to YAML config file | - |
 | `--verbose` | Enable verbose output | false |
 | `--debug` | Enable debug output | false |
@@ -156,23 +159,26 @@ See [config.example.yaml](config.example.yaml) for a complete example with all a
 |-----------------|------------|-------|
 | `Int8`, `Int16`, `Int32` | `int32` | |
 | `Int64` | `int64` | Can be converted to `string` (see BigInt Conversion below) |
-| `Int128`, `Int256` | `string` | No native support in protobuf |
+| `Int128`, `Int256`, `UInt128`, `UInt256` | `string` | No native support in protobuf |
 | `UInt8`, `UInt16`, `UInt32` | `uint32` | |
 | `UInt64` | `uint64` | Can be converted to `string` (see BigInt Conversion below) |
 | `Float32` | `float` | |
 | `Float64` | `double` | |
 | `Decimal*` | `string` | Preserves precision |
 | `String`, `FixedString` | `string` | |
-| `Date`, `DateTime` | `string` | ISO 8601 format |
+| `Date`, `Date32` | `string` | `YYYY-MM-DD` format |
+| `DateTime` | `uint32` | Unix timestamp (seconds) |
+| `DateTime64` | `int64` | Unix timestamp (microseconds) |
 | `Bool` | `bool` | |
 | `UUID` | `string` | |
 | `Array(T)` | `repeated T` | |
-| `Nullable(T)` | Uses nullable filter types | Special handling for filtering |
+| `Nullable(T)` | Google wrapper type | e.g. `Nullable(String)` -> `google.protobuf.StringValue` |
 | `LowCardinality(T)` | `T` | Unwraps to base type |
-| `Map` | `string` | JSON representation |
+| `Map(K, V)` | `map<K, V>` | Native proto map; falls back to `string` for unsupported key types |
 | `Tuple` | `string` | JSON representation |
 | `Enum8`, `Enum16` | `string` | Enum value as string |
 | `IPv4`, `IPv6` | `string` | IP address as string |
+| `JSON` | `string` | JSON representation |
 
 ### BigInt to String Conversion
 
@@ -263,17 +269,27 @@ syntax = "proto3";
 
 package myapp.v1;
 
+import "common.proto";
+import "google/protobuf/wrappers.proto";
+
 option go_package = "github.com/myorg/myapp/gen/v1";
 
 // User accounts table
 message Users {
   uint64 id = 11;
   string email = 12;
-  optional string name = 13;
-  string created_at = 14;
+  google.protobuf.StringValue name = 13;  // Nullable(String) -> wrapper type
+  uint32 created_at = 14;                  // DateTime -> Unix seconds
   repeated string tags = 15;
 }
 ```
+
+> Field numbers are derived from each column's ordinal position plus an offset of 10
+> (so the first column is `11`), leaving `1-10` reserved.
+>
+> Because this table has an `ORDER BY` key, a `UsersService` with `List` and `Get`
+> RPCs (and their request/response messages, with per-column filters) is also
+> generated — omitted here for brevity.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ See [config.example.yaml](config.example.yaml) for a complete example with all a
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--dsn` | ClickHouse DSN | Required |
-| `--tables` | Comma-separated list of tables | Required |
+| `--tables` | Comma-separated list of tables | Required (unless `--all-tables`) |
+| `--all-tables` | Generate for all non-system tables in the database (ignores `--tables`) | false |
 | `--out` | Output directory | `./proto` |
 | `--package` | Proto package name | `clickhouse.v1` |
 | `--go-package` | Go package import path | - |
@@ -243,6 +244,19 @@ This generates:
 clickhouse-proto-gen \
   --dsn "clickhouse://localhost:9000" \
   --tables "db1.users,db2.products,db3.orders" \
+  --out ./proto
+```
+
+### Example 3: Generate for every table in a database
+
+Omit `--tables` and pass `--all-tables` to discover and generate proto for all
+non-system tables (everything outside `system`, `information_schema`, and
+`INFORMATION_SCHEMA`):
+
+```bash
+clickhouse-proto-gen \
+  --dsn "clickhouse://localhost:9000/mydb" \
+  --all-tables \
   --out ./proto
 ```
 

--- a/cmd/clickhouse-proto-gen/main.go
+++ b/cmd/clickhouse-proto-gen/main.go
@@ -165,7 +165,7 @@ func run(_ *cobra.Command, _ []string) error {
 			tbl = parts[1]
 		} else {
 			// Extract database from DSN if not specified
-			db = extractDatabaseFromDSN(cfg.DSN)
+			db = clickhouse.DatabaseFromDSN(cfg.DSN)
 			tbl = tableName
 		}
 
@@ -223,23 +223,4 @@ func getTableList(_ context.Context, _ clickhouse.Service, cfg *config.Config, l
 	tablesToProcess := cfg.Tables
 	log.WithField("table_count", len(tablesToProcess)).Debug("Tables to process")
 	return tablesToProcess
-}
-
-func extractDatabaseFromDSN(dsn string) string {
-	// Basic extraction - finds the database name from DSN
-	// Format: clickhouse://user:pass@host:port/database
-
-	parts := strings.Split(dsn, "/")
-	if len(parts) > 0 {
-		dbPart := parts[len(parts)-1]
-		// Remove any query parameters
-		if idx := strings.Index(dbPart, "?"); idx > 0 {
-			dbPart = dbPart[:idx]
-		}
-		if dbPart != "" {
-			return dbPart
-		}
-	}
-
-	return "default"
 }

--- a/cmd/clickhouse-proto-gen/main.go
+++ b/cmd/clickhouse-proto-gen/main.go
@@ -33,6 +33,7 @@ var (
 var (
 	dsn                  string
 	tables               string
+	allTables            bool
 	outputDir            string
 	pkg                  string
 	goPackage            string
@@ -76,6 +77,7 @@ func init() {
 
 	// Table selection flags
 	rootCmd.Flags().StringVar(&tables, "tables", "", "Comma-separated list of tables to generate (e.g., users,orders or db.users,db.orders)")
+	rootCmd.Flags().BoolVar(&allTables, "all-tables", false, "Generate proto for all non-system tables in the database (ignores --tables)")
 
 	// Output configuration flags
 	rootCmd.Flags().StringVar(&outputDir, "out", "./proto", "Output directory for generated proto files")
@@ -117,7 +119,7 @@ func run(_ *cobra.Command, _ []string) error {
 	}
 
 	// Merge command-line flags (override config file values)
-	cfg.MergeFlags(dsn, outputDir, pkg, goPackage, tables, includeComments, maxPageSize, enableAPI, apiBasePath, apiTablePrefixes, bigIntToStringFields)
+	cfg.MergeFlags(dsn, outputDir, pkg, goPackage, tables, allTables, includeComments, maxPageSize, enableAPI, apiBasePath, apiTablePrefixes, bigIntToStringFields)
 
 	// Validate configuration
 	if err := cfg.Validate(); err != nil {
@@ -145,7 +147,10 @@ func run(_ *cobra.Command, _ []string) error {
 	}()
 
 	// Get tables to process
-	tablesToProcess := getTableList(ctx, ch, cfg, log)
+	tablesToProcess, err := getTableList(ctx, ch, cfg, log)
+	if err != nil {
+		return fmt.Errorf("failed to determine tables to process: %w", err)
+	}
 
 	if len(tablesToProcess) == 0 {
 		log.Warn("No tables found to process")
@@ -218,9 +223,22 @@ func setupLogger() logrus.FieldLogger {
 	return log
 }
 
-func getTableList(_ context.Context, _ clickhouse.Service, cfg *config.Config, log logrus.FieldLogger) []string {
-	// Use specified tables
-	tablesToProcess := cfg.Tables
-	log.WithField("table_count", len(tablesToProcess)).Debug("Tables to process")
-	return tablesToProcess
+func getTableList(ctx context.Context, ch clickhouse.Service, cfg *config.Config, log logrus.FieldLogger) ([]string, error) {
+	// Discover all non-system tables in the target database when --all-tables is set.
+	if cfg.AllTables {
+		database := clickhouse.DatabaseFromDSN(cfg.DSN)
+		tables, err := ch.ListTables(ctx, database)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list tables: %w", err)
+		}
+		log.WithFields(logrus.Fields{
+			"database":    database,
+			"table_count": len(tables),
+		}).Info("Discovered tables via --all-tables")
+		return tables, nil
+	}
+
+	// Otherwise use the explicitly specified tables.
+	log.WithField("table_count", len(cfg.Tables)).Debug("Tables to process")
+	return cfg.Tables, nil
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,12 +3,17 @@
 # ClickHouse connection DSN
 dsn: clickhouse://user:password@localhost:9000/mydb
 
-# Tables to generate proto files for (required)
+# Tables to generate proto files for (required unless all_tables is true)
 # Can specify as table name or database.table
 tables:
   - users
   - orders
   - products
+
+# Generate proto for all non-system tables in the database.
+# When true, the explicit `tables` list above is ignored and every table
+# outside the system schemas is discovered automatically.
+all_tables: false
 
 # Output directory for generated proto files
 output_dir: ./proto

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,12 @@
 module github.com/ethpandaops/clickhouse-proto-gen
 
-go 1.24.6
+go 1.26.3
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.40.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
-	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -111,7 +111,6 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/internal/clickhouse/client.go
+++ b/internal/clickhouse/client.go
@@ -12,6 +12,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Log field keys.
+const (
+	logFieldDatabase = "database"
+	logFieldTable    = "table"
+
+	// engineDistributed is the ClickHouse engine name for distributed tables.
+	engineDistributed = "Distributed"
+)
+
 // Service defines the interface for ClickHouse operations
 type Service interface {
 	Connect(ctx context.Context) error
@@ -52,8 +61,8 @@ func (s *service) Connect(ctx context.Context) error {
 
 	s.conn = conn
 	s.log.WithFields(logrus.Fields{
-		"database": options.Auth.Database,
-		"address":  options.Addr,
+		logFieldDatabase: options.Auth.Database,
+		"address":        options.Addr,
 	}).Info("Connected to ClickHouse")
 
 	return nil
@@ -105,8 +114,9 @@ func (s *service) GetTable(ctx context.Context, database, tableName string) (*Ta
 		Projections: []Projection{},
 	}
 
-	// Get table metadata
-	if err := s.loadTableMetadata(ctx, database, tableName, table); err != nil {
+	// Get table metadata. The engine info is reused below for distributed tables.
+	engine, engineFull, err := s.loadTableMetadata(ctx, database, tableName, table)
+	if err != nil {
 		s.log.WithError(err).Warn("Failed to get table metadata")
 	}
 
@@ -126,28 +136,33 @@ func (s *service) GetTable(ctx context.Context, database, tableName string) (*Ta
 		table.Projections = projections
 	}
 
-	// For distributed tables, also get projections from the underlying local table
-	s.loadDistributedTableProjections(ctx, database, tableName, table)
+	// For distributed tables, also get projections from the underlying local table.
+	// Reuse the engine info already fetched above instead of re-querying system.tables.
+	if engine == engineDistributed {
+		s.loadDistributedTableProjections(ctx, engineFull, table)
+	}
 
 	s.log.WithFields(logrus.Fields{
-		"database": database,
-		"table":    tableName,
-		"columns":  len(table.Columns),
+		logFieldDatabase: database,
+		logFieldTable:    tableName,
+		"columns":        len(table.Columns),
 	}).Debug("Retrieved table schema")
 
 	return table, nil
 }
 
-// loadTableMetadata loads table metadata including comment and sorting key
-func (s *service) loadTableMetadata(ctx context.Context, database, tableName string, table *Table) error {
+// loadTableMetadata loads table metadata including comment and sorting key.
+// It returns the table's engine and engine_full definitions so callers can reuse
+// them (e.g. for distributed tables) without re-querying system.tables.
+func (s *service) loadTableMetadata(ctx context.Context, database, tableName string, table *Table) (engine, engineFull string, err error) {
 	metaQuery := `
 		SELECT comment, sorting_key, engine, engine_full
 		FROM system.tables
 		WHERE database = ? AND name = ?
 	`
-	var comment, sortingKey, engine, engineFull sql.NullString
-	if err := s.conn.QueryRow(ctx, metaQuery, database, tableName).Scan(&comment, &sortingKey, &engine, &engineFull); err != nil {
-		return err
+	var comment, sortingKey, engineNull, engineFullNull sql.NullString
+	if err := s.conn.QueryRow(ctx, metaQuery, database, tableName).Scan(&comment, &sortingKey, &engineNull, &engineFullNull); err != nil {
+		return "", "", err
 	}
 
 	if comment.Valid {
@@ -155,8 +170,8 @@ func (s *service) loadTableMetadata(ctx context.Context, database, tableName str
 	}
 
 	// Load sorting key
-	s.loadSortingKey(ctx, table, sortingKey, engine, engineFull)
-	return nil
+	s.loadSortingKey(ctx, table, sortingKey, engineNull, engineFullNull)
+	return engineNull.String, engineFullNull.String, nil
 }
 
 // loadSortingKey loads the sorting key for a table
@@ -168,7 +183,7 @@ func (s *service) loadSortingKey(ctx context.Context, table *Table, sortingKey, 
 	}
 
 	// For distributed tables, get sorting key from underlying table
-	if !engine.Valid || engine.String != "Distributed" {
+	if !engine.Valid || engine.String != engineDistributed {
 		return
 	}
 
@@ -282,8 +297,8 @@ func (s *service) GetTables(ctx context.Context, database string, tableNames []s
 		table, err := s.GetTable(ctx, db, tbl)
 		if err != nil {
 			s.log.WithError(err).WithFields(logrus.Fields{
-				"database": db,
-				"table":    tbl,
+				logFieldDatabase: db,
+				logFieldTable:    tbl,
 			}).Warn("Failed to get table, skipping")
 			continue
 		}
@@ -374,6 +389,17 @@ func splitDistributedArgs(args string) []string {
 	}
 
 	return result
+}
+
+// DatabaseFromDSN extracts the database name from a ClickHouse DSN.
+// It returns "default" when the DSN omits the database or cannot be parsed.
+func DatabaseFromDSN(dsn string) string {
+	options, err := clickhouse.ParseDSN(dsn)
+	if err != nil || options.Auth.Database == "" {
+		return "default"
+	}
+
+	return options.Auth.Database
 }
 
 func extractBaseType(clickhouseType string) string {
@@ -467,44 +493,11 @@ func (s *service) loadTableProjections(ctx context.Context, database, tableName 
 	return projections, nil
 }
 
-// isDistributedTable checks if a table is a distributed table
-func (s *service) isDistributedTable(ctx context.Context, database, tableName string) bool {
-	query := `
-		SELECT engine
-		FROM system.tables
-		WHERE database = ? AND name = ?
-	`
-	var engine sql.NullString
-	if err := s.conn.QueryRow(ctx, query, database, tableName).Scan(&engine); err != nil {
-		return false
-	}
-	return engine.Valid && engine.String == "Distributed"
-}
-
-// getUnderlyingTableName gets the underlying table info for a distributed table
-func (s *service) getUnderlyingTableName(ctx context.Context, database, tableName string) *underlyingTableInfo {
-	query := `
-		SELECT engine_full
-		FROM system.tables
-		WHERE database = ? AND name = ?
-	`
-	var engineFull sql.NullString
-	if err := s.conn.QueryRow(ctx, query, database, tableName).Scan(&engineFull); err != nil {
-		return nil
-	}
-	if !engineFull.Valid {
-		return nil
-	}
-	return s.extractUnderlyingTable(engineFull.String)
-}
-
-// loadDistributedTableProjections loads projections from underlying local table for distributed tables
-func (s *service) loadDistributedTableProjections(ctx context.Context, database, tableName string, table *Table) {
-	if !s.isDistributedTable(ctx, database, tableName) {
-		return
-	}
-
-	underlyingTable := s.getUnderlyingTableName(ctx, database, tableName)
+// loadDistributedTableProjections loads projections from the underlying local table
+// for a distributed table. The engineFull definition is supplied by the caller (from
+// loadTableMetadata) to avoid re-querying system.tables.
+func (s *service) loadDistributedTableProjections(ctx context.Context, engineFull string, table *Table) {
+	underlyingTable := s.extractUnderlyingTable(engineFull)
 	if underlyingTable == nil {
 		return
 	}
@@ -512,8 +505,8 @@ func (s *service) loadDistributedTableProjections(ctx context.Context, database,
 	localProjections, err := s.loadTableProjections(ctx, underlyingTable.Database, underlyingTable.Table)
 	if err != nil {
 		s.log.WithError(err).WithFields(logrus.Fields{
-			"database": underlyingTable.Database,
-			"table":    underlyingTable.Table,
+			logFieldDatabase: underlyingTable.Database,
+			logFieldTable:    underlyingTable.Table,
 		}).Debug("Failed to get projections from underlying local table")
 		return
 	}

--- a/internal/clickhouse/client.go
+++ b/internal/clickhouse/client.go
@@ -25,9 +25,8 @@ const (
 type Service interface {
 	Connect(ctx context.Context) error
 	Close() error
-	ListTables(ctx context.Context) ([]string, error)
+	ListTables(ctx context.Context, database string) ([]string, error)
 	GetTable(ctx context.Context, database, tableName string) (*Table, error)
-	GetTables(ctx context.Context, database string, tableNames []string) ([]*Table, error)
 }
 
 type service struct {
@@ -75,15 +74,23 @@ func (s *service) Close() error {
 	return nil
 }
 
-func (s *service) ListTables(ctx context.Context) ([]string, error) {
+func (s *service) ListTables(ctx context.Context, database string) ([]string, error) {
 	query := `
 		SELECT database || '.' || name AS full_name
 		FROM system.tables
 		WHERE database NOT IN ('system', 'information_schema', 'INFORMATION_SCHEMA')
-		ORDER BY database, name
 	`
 
-	rows, err := s.conn.Query(ctx, query)
+	// Scope to a single database when one is supplied so callers don't
+	// accidentally generate proto for every database in the instance.
+	args := make([]any, 0, 1)
+	if database != "" {
+		query += " AND database = ?"
+		args = append(args, database)
+	}
+	query += " ORDER BY database, name"
+
+	rows, err := s.conn.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query tables: %w", err)
 	}
@@ -278,35 +285,6 @@ func (s *service) loadTableColumns(ctx context.Context, database, tableName stri
 	}
 
 	return columns, nil
-}
-
-func (s *service) GetTables(ctx context.Context, database string, tableNames []string) ([]*Table, error) {
-	tables := make([]*Table, 0, len(tableNames))
-
-	for _, tableName := range tableNames {
-		// Parse database.table format if present
-		parts := strings.Split(tableName, ".")
-		db := database
-		tbl := tableName
-
-		if len(parts) == 2 {
-			db = parts[0]
-			tbl = parts[1]
-		}
-
-		table, err := s.GetTable(ctx, db, tbl)
-		if err != nil {
-			s.log.WithError(err).WithFields(logrus.Fields{
-				logFieldDatabase: db,
-				logFieldTable:    tbl,
-			}).Warn("Failed to get table, skipping")
-			continue
-		}
-
-		tables = append(tables, table)
-	}
-
-	return tables, nil
 }
 
 // underlyingTableInfo holds information about an underlying table for distributed tables

--- a/internal/clickhouse/client.go
+++ b/internal/clickhouse/client.go
@@ -383,22 +383,22 @@ func extractBaseType(clickhouseType string) string {
 		stripped := false
 
 		// Remove Nullable wrapper
-		if strings.HasPrefix(clickhouseType, "Nullable(") {
-			clickhouseType = strings.TrimPrefix(clickhouseType, "Nullable(")
+		if after, ok := strings.CutPrefix(clickhouseType, "Nullable("); ok {
+			clickhouseType = after
 			clickhouseType = strings.TrimSuffix(clickhouseType, ")")
 			stripped = true
 		}
 
 		// Remove Array wrapper
-		if strings.HasPrefix(clickhouseType, "Array(") {
-			clickhouseType = strings.TrimPrefix(clickhouseType, "Array(")
+		if after, ok := strings.CutPrefix(clickhouseType, "Array("); ok {
+			clickhouseType = after
 			clickhouseType = strings.TrimSuffix(clickhouseType, ")")
 			stripped = true
 		}
 
 		// Remove LowCardinality wrapper
-		if strings.HasPrefix(clickhouseType, "LowCardinality(") {
-			clickhouseType = strings.TrimPrefix(clickhouseType, "LowCardinality(")
+		if after, ok := strings.CutPrefix(clickhouseType, "LowCardinality("); ok {
+			clickhouseType = after
 			clickhouseType = strings.TrimSuffix(clickhouseType, ")")
 			stripped = true
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,12 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Default configuration values.
+const (
+	defaultOutputDir   = "./proto"
+	defaultAPIBasePath = "/api/v1"
+)
+
 // Define static errors for validation
 var (
 	ErrDSNRequired       = errors.New("DSN is required")
@@ -54,11 +60,11 @@ type ConversionConfig struct {
 // NewConfig creates a new Config instance with default values.
 func NewConfig() *Config {
 	return &Config{
-		OutputDir:        "./proto",
+		OutputDir:        defaultOutputDir,
 		Package:          "clickhouse.v1",
 		IncludeComments:  true,
 		MaxPageSize:      10000,
-		APIBasePath:      "/api/v1",
+		APIBasePath:      defaultAPIBasePath,
 		EnableAPI:        false,
 		APITablePrefixes: []string{},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -152,10 +153,8 @@ func (c *Config) MergeFlags(dsn, outputDir, pkg, goPkg, tables string, includeCo
 func (cc *ConversionConfig) ShouldConvertToString(tableName, fieldName string) bool {
 	// Check table-scoped configuration (bigint_to_string)
 	if fields, ok := cc.BigIntToString[tableName]; ok {
-		for _, f := range fields {
-			if f == fieldName {
-				return true
-			}
+		if slices.Contains(fields, fieldName) {
+			return true
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ var (
 type Config struct {
 	DSN             string   `yaml:"dsn"`
 	Tables          []string `yaml:"tables"`
+	AllTables       bool     `yaml:"all_tables"` // Generate for all non-system tables (ignores Tables)
 	OutputDir       string   `yaml:"output_dir"`
 	Package         string   `yaml:"package"`
 	GoPackage       string   `yaml:"go_package"`
@@ -101,7 +102,8 @@ func (c *Config) Validate() error {
 		return ErrPackageRequired
 	}
 
-	if len(c.Tables) == 0 {
+	// Either an explicit table list or --all-tables discovery is required.
+	if len(c.Tables) == 0 && !c.AllTables {
 		return ErrTablesRequired
 	}
 
@@ -109,7 +111,7 @@ func (c *Config) Validate() error {
 }
 
 // MergeFlags merges command-line flags into the configuration.
-func (c *Config) MergeFlags(dsn, outputDir, pkg, goPkg, tables string, includeComments bool, maxPageSize int32, enableAPI bool, apiBasePath, apiTablePrefixes, bigIntToStringFields string) {
+func (c *Config) MergeFlags(dsn, outputDir, pkg, goPkg, tables string, allTables, includeComments bool, maxPageSize int32, enableAPI bool, apiBasePath, apiTablePrefixes, bigIntToStringFields string) {
 	if dsn != "" {
 		c.DSN = dsn
 	}
@@ -127,6 +129,9 @@ func (c *Config) MergeFlags(dsn, outputDir, pkg, goPkg, tables string, includeCo
 		for i := range c.Tables {
 			c.Tables[i] = strings.TrimSpace(c.Tables[i])
 		}
+	}
+	if allTables {
+		c.AllTables = true
 	}
 	c.IncludeComments = includeComments
 	if maxPageSize > 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -94,6 +94,17 @@ func TestConfig_Validate(t *testing.T) {
 			expectErr: ErrTablesRequired,
 		},
 		{
+			name: "AllTables satisfies table requirement",
+			config: Config{
+				DSN:       "clickhouse://localhost:9000/test",
+				OutputDir: "./proto",
+				Package:   "test.v1",
+				Tables:    nil,
+				AllTables: true,
+			},
+			wantErr: false,
+		},
+		{
 			name: "Complete configuration with GoPackage",
 			config: Config{
 				DSN:             "clickhouse://localhost:9000/test",
@@ -259,6 +270,7 @@ func TestConfig_MergeFlags(t *testing.T) {
 		pkg              string
 		goPkg            string
 		tables           string
+		allTables        bool
 		includeComments  bool
 		enableAPI        bool
 		apiBasePath      string
@@ -385,6 +397,28 @@ func TestConfig_MergeFlags(t *testing.T) {
 			expected: Config{
 				Tables:          []string{"db1.users", "db2.orders", "db3.products"},
 				IncludeComments: false,
+			},
+		},
+		{
+			name: "All-tables flag sets AllTables",
+			initial: Config{
+				DSN:       "clickhouse://localhost:9000/test",
+				OutputDir: "./proto",
+			},
+			dsn:              "",
+			outputDir:        "",
+			pkg:              "",
+			goPkg:            "",
+			tables:           "",
+			allTables:        true,
+			includeComments:  false,
+			enableAPI:        false,
+			apiBasePath:      "",
+			apiTablePrefixes: "",
+			expected: Config{
+				DSN:       "clickhouse://localhost:9000/test",
+				OutputDir: "./proto",
+				AllTables: true,
 			},
 		},
 		{
@@ -540,7 +574,7 @@ func TestConfig_MergeFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := tt.initial
-			cfg.MergeFlags(tt.dsn, tt.outputDir, tt.pkg, tt.goPkg, tt.tables, tt.includeComments, 0, tt.enableAPI, tt.apiBasePath, tt.apiTablePrefixes, "")
+			cfg.MergeFlags(tt.dsn, tt.outputDir, tt.pkg, tt.goPkg, tt.tables, tt.allTables, tt.includeComments, 0, tt.enableAPI, tt.apiBasePath, tt.apiTablePrefixes, "")
 			assert.Equal(t, tt.expected, cfg)
 		})
 	}

--- a/internal/protogen/generator.go
+++ b/internal/protogen/generator.go
@@ -608,8 +608,8 @@ func (g *Generator) writeComment(sb *strings.Builder, comment, indent string) {
 	if !g.config.IncludeComments {
 		return
 	}
-	lines := strings.Split(comment, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(comment, "\n")
+	for line := range lines {
 		line = strings.TrimSpace(line)
 		if line != "" {
 			fmt.Fprintf(sb, "%s// %s\n", indent, line)

--- a/internal/protogen/generator.go
+++ b/internal/protogen/generator.go
@@ -14,14 +14,35 @@ import (
 
 // ClickHouse type constants
 const (
-	typeInt8   = "Int8"
-	typeInt16  = "Int16"
-	typeInt32  = "Int32"
-	typeInt64  = "Int64"
-	typeUInt8  = "UInt8"
-	typeUInt16 = "UInt16"
-	typeUInt32 = "UInt32"
-	typeUInt64 = "UInt64"
+	typeInt8        = "Int8"
+	typeInt16       = "Int16"
+	typeInt32       = "Int32"
+	typeInt64       = "Int64"
+	typeInt128      = "Int128"
+	typeInt256      = "Int256"
+	typeUInt8       = "UInt8"
+	typeUInt16      = "UInt16"
+	typeUInt32      = "UInt32"
+	typeUInt64      = "UInt64"
+	typeUInt128     = "UInt128"
+	typeUInt256     = "UInt256"
+	typeFloat32     = "Float32"
+	typeFloat64     = "Float64"
+	typeBool        = "Bool"
+	typeFixedString = "FixedString"
+	typeUUID        = "UUID"
+	typeIPv4        = "IPv4"
+	typeIPv6        = "IPv6"
+	typeJSON        = "JSON"
+	typeEnum8       = "Enum8"
+	typeEnum16      = "Enum16"
+	typeMap         = "Map"
+)
+
+// Log field keys.
+const (
+	logFieldTable = "table"
+	logFieldField = "field"
 )
 
 // Generator creates protobuf files from ClickHouse tables
@@ -87,8 +108,8 @@ func (g *Generator) Generate(tables []*clickhouse.Table) error {
 	for _, table := range tables {
 		if err := g.generateTableFile(table); err != nil {
 			g.log.WithError(err).WithFields(logrus.Fields{
-				"database": table.Database,
-				"table":    table.Name,
+				"database":    table.Database,
+				logFieldTable: table.Name,
 			}).Error("Failed to generate proto file")
 			return err
 		}
@@ -630,15 +651,15 @@ func (g *Generator) writeFile(filename, content string) error {
 func getProtoType(baseType string) string {
 	switch baseType {
 	case typeInt8, typeInt16, typeInt32:
-		return "int32"
+		return protoInt32
 	case typeInt64:
-		return "int64"
+		return protoInt64
 	case typeUInt8, typeUInt16, typeUInt32:
-		return "uint32"
+		return protoUInt32
 	case typeUInt64:
-		return "uint64"
+		return protoUInt64
 	default:
-		return "string"
+		return protoString
 	}
 }
 
@@ -689,7 +710,7 @@ func (g *Generator) validateTableScopedConversions(convConfig *config.Conversion
 	for tableName, fieldNames := range convConfig.BigIntToString {
 		colMap, tableExists := tableColumns[tableName]
 		if !tableExists {
-			g.log.WithField("table", tableName).Warn("Table specified in bigint_to_string conversion config not found in tables being generated")
+			g.log.WithField(logFieldTable, tableName).Warn("Table specified in bigint_to_string conversion config not found in tables being generated")
 			continue
 		}
 
@@ -703,18 +724,18 @@ func (g *Generator) validateFieldsInTable(tableName string, fieldNames []string,
 		col, exists := colMap[fieldName]
 		if !exists {
 			g.log.WithFields(logrus.Fields{
-				"table": tableName,
-				"field": fieldName,
+				logFieldTable: tableName,
+				logFieldField: fieldName,
 			}).Warn("Field specified in bigint_to_string conversion config not found in table")
 			continue
 		}
 
 		if col.BaseType != typeUInt64 && col.BaseType != typeInt64 {
 			g.log.WithFields(logrus.Fields{
-				"table":    tableName,
-				"field":    fieldName,
-				"type":     col.BaseType,
-				"expected": "Int64 or UInt64",
+				logFieldTable: tableName,
+				logFieldField: fieldName,
+				"type":        col.BaseType,
+				"expected":    "Int64 or UInt64",
 			}).Warn("Field marked for bigint-to-string conversion is not Int64/UInt64 type")
 		}
 	}
@@ -746,11 +767,11 @@ func (g *Generator) validatePattern(pattern, tablePattern, fieldPattern string, 
 			found = true
 			if col.BaseType != typeUInt64 && col.BaseType != typeInt64 {
 				g.log.WithFields(logrus.Fields{
-					"table":    tableName,
-					"field":    fieldPattern,
-					"pattern":  pattern,
-					"type":     col.BaseType,
-					"expected": "Int64 or UInt64",
+					logFieldTable: tableName,
+					logFieldField: fieldPattern,
+					"pattern":     pattern,
+					"type":        col.BaseType,
+					"expected":    "Int64 or UInt64",
 				}).Warn("Field matching bigint-to-string pattern is not Int64/UInt64 type")
 			}
 		}

--- a/internal/protogen/mapper.go
+++ b/internal/protogen/mapper.go
@@ -22,8 +22,41 @@ const (
 	protoBool   = "bool"
 	protoBytes  = "bytes"
 
+	protoSInt32   = "sint32"
+	protoSInt64   = "sint64"
+	protoFixed32  = "fixed32"
+	protoFixed64  = "fixed64"
+	protoSFixed32 = "sfixed32"
+	protoSFixed64 = "sfixed64"
+	protoMessage  = "message"
+	protoService  = "service"
+
+	protoRepeatedString = "repeated string"
+
 	// ClickHouse type names
 	chTypeString = "String"
+
+	// Google well-known wrapper types
+	wrapperString = "google.protobuf.StringValue"
+	wrapperBool   = "google.protobuf.BoolValue"
+	wrapperInt32  = "google.protobuf.Int32Value"
+	wrapperInt64  = "google.protobuf.Int64Value"
+	wrapperUInt32 = "google.protobuf.UInt32Value"
+	wrapperUInt64 = "google.protobuf.UInt64Value"
+	wrapperFloat  = "google.protobuf.FloatValue"
+	wrapperDouble = "google.protobuf.DoubleValue"
+	wrapperBytes  = "google.protobuf.BytesValue"
+
+	// Generated filter type names
+	filterString          = "StringFilter"
+	filterUInt64          = "UInt64Filter"
+	filterNullableString  = "NullableStringFilter"
+	filterMapStringString = "MapStringStringFilter"
+	filterArrayInt32      = "ArrayInt32Filter"
+	filterArrayInt64      = "ArrayInt64Filter"
+	filterArrayUInt32     = "ArrayUInt32Filter"
+	filterArrayUInt64     = "ArrayUInt64Filter"
+	filterArrayString     = "ArrayStringFilter"
 )
 
 // TypeMapper handles conversion of ClickHouse types to Protobuf types
@@ -42,11 +75,11 @@ func (tm *TypeMapper) MapType(column *clickhouse.Column, tableName string, convC
 	if (baseType == typeUInt64 || baseType == typeInt64) && convConfig.ShouldConvertToString(tableName, column.Name) {
 		// Handle Array(Int64/UInt64) → repeated string
 		if column.IsArray {
-			return "repeated string", nil
+			return protoRepeatedString, nil
 		}
 		// Handle Nullable(Int64/UInt64) → google.protobuf.StringValue
 		if column.IsNullable {
-			return "google.protobuf.StringValue", nil
+			return wrapperString, nil
 		}
 		// Regular Int64/UInt64 → string
 		return protoString, nil
@@ -79,7 +112,7 @@ func (tm *TypeMapper) MapType(column *clickhouse.Column, tableName string, convC
 
 func (tm *TypeMapper) mapBaseType(baseType, fullType string) string {
 	// Handle DateTime64 specially to check precision
-	if baseType == "DateTime64" {
+	if baseType == clickhouseDateTime64 {
 		// DateTime64 uses int64 because toUnixTimestamp64Micro() returns Int64
 		// The precision affects interpretation but not storage type
 		return protoInt64
@@ -107,37 +140,37 @@ func (tm *TypeMapper) mapBaseType(baseType, fullType string) string {
 func (tm *TypeMapper) mapNumericType(baseType string) string {
 	switch baseType {
 	// Integer types
-	case "Int8", "Int16", "Int32":
+	case typeInt8, typeInt16, typeInt32:
 		return protoInt32
-	case "Int64":
+	case typeInt64:
 		return protoInt64
-	case "Int128", "Int256":
+	case typeInt128, typeInt256:
 		return protoString // No native int128/256 in protobuf
 
 	// Unsigned integer types
-	case "UInt8", "UInt16", "UInt32":
+	case typeUInt8, typeUInt16, typeUInt32:
 		return protoUInt32
 	case typeUInt64:
 		return protoUInt64
-	case "UInt128", "UInt256":
+	case typeUInt128, typeUInt256:
 		return protoString // No native uint128/256 in protobuf
 
 	// Float types
-	case "Float32":
+	case typeFloat32:
 		return protoFloat
-	case "Float64":
+	case typeFloat64:
 		return protoDouble
 
 	// Decimal types
-	case "Decimal", "Decimal32", "Decimal64", "Decimal128", "Decimal256":
+	case clickhouseDecimal, clickhouseDecimal32, clickhouseDecimal64, clickhouseDecimal128, clickhouseDecimal256:
 		return protoString // Represent decimals as strings to preserve precision
 
 	// Boolean type
-	case "Bool":
+	case typeBool:
 		return protoBool
 
 	// DateTime type
-	case "DateTime":
+	case clickhouseDateTime:
 		return protoUInt32 // Unix timestamp in seconds
 	}
 
@@ -147,23 +180,23 @@ func (tm *TypeMapper) mapNumericType(baseType string) string {
 func (tm *TypeMapper) mapStringType(baseType string) string {
 	switch baseType {
 	// String types
-	case chTypeString, "FixedString":
+	case chTypeString, typeFixedString:
 		return protoString
 
 	// Date types (as strings for readability)
-	case "Date", "Date32":
+	case clickhouseDate, clickhouseDate32:
 		return protoString // YYYY-MM-DD format
 
 	// UUID type
-	case "UUID":
+	case typeUUID:
 		return protoString
 
 	// IP address types
-	case "IPv4", "IPv6":
+	case typeIPv4, typeIPv6:
 		return protoString
 
 	// JSON type
-	case "JSON":
+	case typeJSON:
 		return protoString
 
 	// Binary data
@@ -171,7 +204,7 @@ func (tm *TypeMapper) mapStringType(baseType string) string {
 		return protoBytes
 
 	// Enum types
-	case "Enum8", "Enum16":
+	case typeEnum8, typeEnum16:
 		return protoString // Would need special handling for enum definitions
 
 	// Geo types
@@ -193,7 +226,7 @@ func (tm *TypeMapper) mapSpecialType(baseType, fullType string) string {
 		return protoString
 
 	// Map type - use protobuf's native map syntax
-	case "Map":
+	case typeMap:
 		keyType, valueType := tm.parseMapType(fullType)
 		if keyType == "" || valueType == "" {
 			// Invalid map format, fallback to string
@@ -238,18 +271,18 @@ func (tm *TypeMapper) mapClickHouseTypeToProto(chType string) string {
 // fixed32, fixed64, sfixed32, sfixed64, bool, string
 func (tm *TypeMapper) isValidProtoMapKey(protoType string) bool {
 	validKeys := map[string]bool{
-		"int32":    true,
-		"int64":    true,
-		"uint32":   true,
-		"uint64":   true,
-		"sint32":   true,
-		"sint64":   true,
-		"fixed32":  true,
-		"fixed64":  true,
-		"sfixed32": true,
-		"sfixed64": true,
-		"bool":     true,
-		"string":   true,
+		protoInt32:    true,
+		protoInt64:    true,
+		protoUInt32:   true,
+		protoUInt64:   true,
+		protoSInt32:   true,
+		protoSInt64:   true,
+		protoFixed32:  true,
+		protoFixed64:  true,
+		protoSFixed32: true,
+		protoSFixed64: true,
+		protoBool:     true,
+		protoString:   true,
 	}
 
 	return validKeys[protoType]
@@ -270,23 +303,23 @@ func extractInnerType(wrappedType string) string {
 func (tm *TypeMapper) getWrapperType(protoType string) string {
 	switch protoType {
 	case protoString:
-		return "google.protobuf.StringValue"
+		return wrapperString
 	case protoBool:
-		return "google.protobuf.BoolValue"
+		return wrapperBool
 	case protoInt32:
-		return "google.protobuf.Int32Value"
+		return wrapperInt32
 	case protoInt64:
-		return "google.protobuf.Int64Value"
+		return wrapperInt64
 	case protoUInt32:
-		return "google.protobuf.UInt32Value"
+		return wrapperUInt32
 	case protoUInt64:
-		return "google.protobuf.UInt64Value"
+		return wrapperUInt64
 	case protoFloat:
-		return "google.protobuf.FloatValue"
+		return wrapperFloat
 	case protoDouble:
-		return "google.protobuf.DoubleValue"
+		return wrapperDouble
 	case protoBytes:
-		return "google.protobuf.BytesValue"
+		return wrapperBytes
 	default:
 		// For non-primitive types, return empty string
 		return ""
@@ -361,40 +394,40 @@ func SanitizeName(name string) string {
 
 func isReservedKeyword(word string) bool {
 	reserved := map[string]bool{
-		"syntax":     true,
-		"package":    true,
-		"import":     true,
-		"public":     true,
-		"option":     true,
-		"message":    true,
-		"enum":       true,
-		"service":    true,
-		"rpc":        true,
-		"returns":    true,
-		"stream":     true,
-		"repeated":   true,
-		"optional":   true,
-		"required":   true,
-		"reserved":   true,
-		"extensions": true,
-		"extend":     true,
-		"oneof":      true,
-		"map":        true,
-		"bool":       true,
-		"string":     true,
-		"bytes":      true,
-		"float":      true,
-		"double":     true,
-		"int32":      true,
-		"int64":      true,
-		"uint32":     true,
-		"uint64":     true,
-		"sint32":     true,
-		"sint64":     true,
-		"fixed32":    true,
-		"fixed64":    true,
-		"sfixed32":   true,
-		"sfixed64":   true,
+		"syntax":      true,
+		"package":     true,
+		"import":      true,
+		"public":      true,
+		"option":      true,
+		protoMessage:  true,
+		"enum":        true,
+		protoService:  true,
+		"rpc":         true,
+		"returns":     true,
+		"stream":      true,
+		"repeated":    true,
+		"optional":    true,
+		"required":    true,
+		"reserved":    true,
+		"extensions":  true,
+		"extend":      true,
+		"oneof":       true,
+		"map":         true,
+		protoBool:     true,
+		protoString:   true,
+		protoBytes:    true,
+		protoFloat:    true,
+		protoDouble:   true,
+		protoInt32:    true,
+		protoInt64:    true,
+		protoUInt32:   true,
+		protoUInt64:   true,
+		protoSInt32:   true,
+		protoSInt64:   true,
+		protoFixed32:  true,
+		protoFixed64:  true,
+		protoSFixed32: true,
+		protoSFixed64: true,
 	}
 
 	return reserved[strings.ToLower(word)]
@@ -486,17 +519,17 @@ func (tm *TypeMapper) getMapFilterType(columnType string) string {
 	}
 
 	// Currently supporting common combinations with String keys
-	if keyType == "String" {
+	if keyType == chTypeString {
 		switch valueType {
-		case "String":
-			return "MapStringStringFilter"
-		case "UInt32", "UInt8", "UInt16":
+		case chTypeString:
+			return filterMapStringString
+		case typeUInt32, typeUInt8, typeUInt16:
 			return "MapStringUInt32Filter"
 		case typeUInt64:
 			return "MapStringUInt64Filter"
-		case "Int32", "Int8", "Int16":
+		case typeInt32, typeInt8, typeInt16:
 			return "MapStringInt32Filter"
-		case "Int64":
+		case typeInt64:
 			return "MapStringInt64Filter"
 		}
 	}
@@ -519,9 +552,9 @@ func (tm *TypeMapper) getScalarFilterType(column *clickhouse.Column) string {
 	case protoUInt32:
 		baseFilterType = "UInt32Filter"
 	case protoUInt64:
-		baseFilterType = "UInt64Filter"
+		baseFilterType = filterUInt64
 	case protoString:
-		baseFilterType = "StringFilter"
+		baseFilterType = filterString
 	case protoBool:
 		baseFilterType = "BoolFilter"
 	default:
@@ -543,15 +576,15 @@ func (tm *TypeMapper) getArrayFilterType(column *clickhouse.Column) string {
 
 	switch protoType {
 	case protoInt32:
-		return "ArrayInt32Filter"
+		return filterArrayInt32
 	case protoInt64:
-		return "ArrayInt64Filter"
+		return filterArrayInt64
 	case protoUInt32:
-		return "ArrayUInt32Filter"
+		return filterArrayUInt32
 	case protoUInt64:
-		return "ArrayUInt64Filter"
+		return filterArrayUInt64
 	case protoString:
-		return "ArrayStringFilter"
+		return filterArrayString
 	default:
 		// Unsupported array element type
 		return ""
@@ -569,13 +602,13 @@ func (tm *TypeMapper) GetFilterTypeForColumn(column *clickhouse.Column, tableNam
 	if (column.BaseType == typeUInt64 || column.BaseType == typeInt64) && convConfig.ShouldConvertToString(tableName, column.Name) {
 		// Use StringFilter for converted Int64/UInt64 fields
 		if column.IsNullable {
-			return "NullableStringFilter"
+			return filterNullableString
 		}
-		return "StringFilter"
+		return filterString
 	}
 
 	// Check if it's a Map type
-	if column.BaseType == "Map" {
+	if column.BaseType == typeMap {
 		return tm.getMapFilterType(column.Type)
 	}
 

--- a/internal/protogen/sql_common_test.go
+++ b/internal/protogen/sql_common_test.go
@@ -442,20 +442,20 @@ func TestCompleteQueryGeneration(t *testing.T) {
 
 type mockQueryBuilder struct {
 	whereClause string
-	args        []interface{}
+	args        []any
 }
 
 func (qb *mockQueryBuilder) GetWhereClause() string {
 	return qb.whereClause
 }
 
-func (qb *mockQueryBuilder) GetArgs() []interface{} {
+func (qb *mockQueryBuilder) GetArgs() []any {
 	return qb.args
 }
 
 type mockSQLQuery struct {
 	Query string
-	Args  []interface{}
+	Args  []any
 }
 
 type mockQueryOptions struct {

--- a/internal/protogen/sql_helper.go
+++ b/internal/protogen/sql_helper.go
@@ -4,6 +4,7 @@ package protogen
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -113,12 +114,7 @@ func getProtocMessageName(tableName string) string {
 // standard Go integer types and are mapped to string in protobuf.
 func needsStringConversion(col *clickhouse.Column) bool {
 	largeIntTypes := []string{"UInt128", "UInt256", "Int128", "Int256"}
-	for _, t := range largeIntTypes {
-		if col.BaseType == t {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(largeIntTypes, col.BaseType)
 }
 
 // hasNullableArrayElements checks if an array column has nullable elements.

--- a/internal/protogen/sql_helper.go
+++ b/internal/protogen/sql_helper.go
@@ -113,7 +113,7 @@ func getProtocMessageName(tableName string) string {
 // Large integer types (UInt128, UInt256, Int128, Int256) are too large for
 // standard Go integer types and are mapped to string in protobuf.
 func needsStringConversion(col *clickhouse.Column) bool {
-	largeIntTypes := []string{"UInt128", "UInt256", "Int128", "Int256"}
+	largeIntTypes := []string{typeUInt128, typeUInt256, typeInt128, typeInt256}
 	return slices.Contains(largeIntTypes, col.BaseType)
 }
 
@@ -130,10 +130,10 @@ func hasNullableArrayElements(col *clickhouse.Column) bool {
 func getDefaultValueForType(baseType string) string {
 	// For numeric types, default to 0
 	numericTypes := []string{
-		"UInt8", "UInt16", "UInt32", typeUInt64, "UInt128", "UInt256",
-		"Int8", "Int16", "Int32", "Int64", "Int128", "Int256",
-		"Float32", "Float64",
-		"Decimal", "Decimal32", "Decimal64", "Decimal128", "Decimal256",
+		typeUInt8, typeUInt16, typeUInt32, typeUInt64, typeUInt128, typeUInt256,
+		typeInt8, typeInt16, typeInt32, typeInt64, typeInt128, typeInt256,
+		typeFloat32, typeFloat64,
+		clickhouseDecimal, clickhouseDecimal32, clickhouseDecimal64, clickhouseDecimal128, clickhouseDecimal256,
 	}
 	for _, t := range numericTypes {
 		if strings.HasPrefix(baseType, t) {
@@ -142,12 +142,12 @@ func getDefaultValueForType(baseType string) string {
 	}
 
 	// For DateTime types, default to 0 (Unix epoch)
-	if strings.HasPrefix(baseType, "DateTime") {
+	if strings.HasPrefix(baseType, clickhouseDateTime) {
 		return "0"
 	}
 
 	// For Date types, default to epoch date
-	if baseType == "Date" || baseType == "Date32" {
+	if baseType == clickhouseDate || baseType == clickhouseDate32 {
 		return "'1970-01-01'"
 	}
 
@@ -184,7 +184,7 @@ func getSelectColumnExpression(col *clickhouse.Column, tableName string, convCon
 	// Handle FixedString types - convert zero-byte strings to NULL
 	// This prevents confusing zero-byte string output in API responses
 	// Check BaseType first (handles Nullable(FixedString(N))), then parse full Type for length
-	if col.BaseType == "FixedString" {
+	if col.BaseType == typeFixedString {
 		if isFixed, length := IsFixedString(col.Type); isFixed {
 			return fmt.Sprintf("NULLIF(`%s`, repeat('\\x00', %d)) AS `%s`", col.Name, length, col.Name)
 		}
@@ -633,7 +633,7 @@ func (g *Generator) handleNumericFilter(sb *strings.Builder, columnName, filterT
 
 // handleMapFilter handles Map filter types
 func (g *Generator) handleMapFilter(sb *strings.Builder, columnName, filterType, indent string) {
-	if filterType == "MapStringStringFilter" {
+	if filterType == filterMapStringString {
 		g.writeMapStringStringFilterCases(sb, columnName, indent)
 		return
 	}


### PR DESCRIPTION
## Toolchain & CI
- Go `1.24.6` → `1.26.3` across `go.mod`, the Dockerfile builder, all GitHub
  Actions workflows, and goreleaser-cross (`v1.26.3`)
- golangci-lint → `v2.12.2`
- Added `.tool-versions` (golang 1.26.3, golangci-lint 2.12.2) to standardize
  local/CI tool versions

## Bug fixes
- **Dockerfile built the wrong target.** It ran `go build -o /bin/app .`, but the
  `main` package lives in `./cmd/clickhouse-proto-gen` — now builds the correct
  package so the image actually produces a working binary.
- **Redundant ClickHouse queries for distributed tables.** `GetTable` re-queried
  `system.tables` two extra times (`isDistributedTable` + `getUnderlyingTableName`)
  for engine info it had already fetched. `loadTableMetadata` now returns the
  `engine`/`engine_full` it read, eliminating both round-trips per distributed table.
- **Fragile DSN parsing.** Replaced the hand-rolled `extractDatabaseFromDSN` string
  splitter with `DatabaseFromDSN`, which uses the ClickHouse driver's own `ParseDSN`.

## New feature: `--all-tables`
- New `--all-tables` flag (and `all_tables:` YAML option) generates proto for every
  non-system table in the **target database**, scoped to the DSN's database so it
  can't accidentally sweep an entire cluster.
- Config validation now requires *either* an explicit `--tables` list *or*
  `--all-tables`.

## Dependency & dead-code cleanup
- Removed the unused `google.golang.org/protobuf` direct dependency (it was pinned
  at `v1.27.1` and imported nowhere — the tool emits `.proto` as text).
- Removed the unused `GetTables` method and the no-op `getTableList` indirection.
- `ListTables` is now database-scoped and actually wired up (it backs `--all-tables`).

## Code modernization (no behavior change)
- Extracted magic strings/numbers into named constants across `protogen`.
- `slices.Contains`, `strings.SplitSeq`, and `interface{}` → `any`.

## Docs
- README: corrected the type-mapping table (`DateTime`→`uint32`, `DateTime64`→`int64`,
  `Map`→`map<K,V>`, `Nullable`→wrapper type), fixed the stale example output, and
  documented the previously-undocumented `--enable-api*` flags plus `--all-tables`.
- `config.example.yaml`: documented `all_tables`.